### PR TITLE
Add removal of old logic to check for the applet path

### DIFF
--- a/Patch/mdloader-applet-path.patch
+++ b/Patch/mdloader-applet-path.patch
@@ -24,7 +24,7 @@
  //Run applet command and wait for device response
  //Return 1 on sucess, 0 on failure
  int run_applet(mailbox_t *mail)
-@@ -754,18 +760,20 @@ int main(int argc, char *argv[])
+@@ -754,14 +760,22 @@ int main(int argc, char *argv[])
      //Load applet
      FILE *fIn;
      char appletfname[128] = "";
@@ -39,16 +39,16 @@
  
 -    fIn = fopen(appletfname, "rb");
 +    fIn = fopen(appletfpath, "rb"); // Try in CWD first
-     if (!fIn)
-     {
--        printf("Error: Could not open applet file: %s\n", appletfname);
--        goto closePort;
++    if (!fIn)
++    {
 +        get_applet_path(appletfname, appletfpath); // If not in CWD, look in $PREFIX/share/mdloader
 +        fIn = fopen(appletfpath, "rb");
-     }
-     else
++    }
++
+     if (!fIn)
      {
-@@ -773,7 +781,7 @@ int main(int argc, char *argv[])
+         printf("Error: Could not open applet file: %s\n", appletfname);
+@@ -773,7 +787,7 @@ int main(int argc, char *argv[])
          int filebytes;
          int readbytes;
  

--- a/Patch/mdloader-applet-path.patch
+++ b/Patch/mdloader-applet-path.patch
@@ -1,3 +1,5 @@
+diff --git a/Makefile b/Makefile
+index cbffc63..d7b6cd7 100644
 --- a/Makefile
 +++ b/Makefile
 @@ -1,7 +1,7 @@
@@ -9,6 +11,8 @@
  
  SRCFILES = mdloader_common.c mdloader_parser.c
  ifeq ($(OS),Windows_NT)
+diff --git a/mdloader_common.c b/mdloader_common.c
+index 4321de2..59f81a3 100644
 --- a/mdloader_common.c
 +++ b/mdloader_common.c
 @@ -179,6 +179,12 @@ int print_mail(mailbox_t *mail)
@@ -24,7 +28,7 @@
  //Run applet command and wait for device response
  //Return 1 on sucess, 0 on failure
  int run_applet(mailbox_t *mail)
-@@ -754,14 +760,21 @@ int main(int argc, char *argv[])
+@@ -754,18 +760,20 @@ int main(int argc, char *argv[])
      //Load applet
      FILE *fIn;
      char appletfname[128] = "";
@@ -39,15 +43,16 @@
  
 -    fIn = fopen(appletfname, "rb");
 +    fIn = fopen(appletfpath, "rb"); // Try in CWD first
-+    if (!fIn)
-+    {
-+        get_applet_path(appletfname, appletfpath); // If not in CWD, look in $PREFIX/share/mdloader
-+        fIn = fopen(appletfpath, "rb");
-+    }
      if (!fIn)
      {
-         printf("Error: Could not open applet file: %s\n", appletfname);
-@@ -773,7 +786,7 @@ int main(int argc, char *argv[])
+-        printf("Error: Could not open applet file: %s\n", appletfname);
+-        goto closePort;
++        get_applet_path(appletfname, appletfpath); // If not in CWD, look in $PREFIX/share/mdloader
++        fIn = fopen(appletfpath, "rb");
+     }
+     else
+     {
+@@ -773,7 +781,7 @@ int main(int argc, char *argv[])
          int filebytes;
          int readbytes;
  
@@ -56,6 +61,8 @@
          if (filebytes == 0)
          {
              printf("Error: Applet file is empty!\n");
+diff --git a/mdloader_common.h b/mdloader_common.h
+index 0bd8575..2d75d6b 100644
 --- a/mdloader_common.h
 +++ b/mdloader_common.h
 @@ -47,6 +47,12 @@

--- a/Patch/mdloader-applet-path.patch
+++ b/Patch/mdloader-applet-path.patch
@@ -1,5 +1,3 @@
-diff --git a/Makefile b/Makefile
-index cbffc63..d7b6cd7 100644
 --- a/Makefile
 +++ b/Makefile
 @@ -1,7 +1,7 @@
@@ -11,8 +9,6 @@ index cbffc63..d7b6cd7 100644
  
  SRCFILES = mdloader_common.c mdloader_parser.c
  ifeq ($(OS),Windows_NT)
-diff --git a/mdloader_common.c b/mdloader_common.c
-index 4321de2..59f81a3 100644
 --- a/mdloader_common.c
 +++ b/mdloader_common.c
 @@ -179,6 +179,12 @@ int print_mail(mailbox_t *mail)
@@ -61,8 +57,6 @@ index 4321de2..59f81a3 100644
          if (filebytes == 0)
          {
              printf("Error: Applet file is empty!\n");
-diff --git a/mdloader_common.h b/mdloader_common.h
-index 0bd8575..2d75d6b 100644
 --- a/mdloader_common.h
 +++ b/mdloader_common.h
 @@ -47,6 +47,12 @@


### PR DESCRIPTION
## Description

The original logic was not removed without these changes, so it would always exit out with the reason it could not find the applet. These changes will remove that if statement so that the intended patch will work correctly.