### PR TITLE
Improve the warning message

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -24,4 +24,4 @@ jobs:
           livecheck: true
           message: |
             **⚠️ Do not merge this PR directly! ⚠️**
-            Label it with `pr-pull` instead to make the bot build and upload the bottle.
+            Wait for `brew test-bot` to complete, then label it with `pr-pull` instead to make the bot build and upload the bottle.


### PR DESCRIPTION
If the `pr-pull` label is added to the PR before `brew test-bot` completes, the action will fail, because the build artifacts do not yet exist.