### PR TITLE
Rebuild bottle

### DIFF
--- a/Formula/qmk.rb
+++ b/Formula/qmk.rb
@@ -8,6 +8,7 @@ class Qmk < Formula
 
   bottle do
     root_url "https://github.com/qmk/homebrew-qmk/releases/download/qmk-1.1.0"
+    rebuild 1
     sha256 cellar: :any, catalina: "90f10c34907159f92ffc188b389835609a8a8f1c5f78bb9ecd56de08b6073455"
   end
 


### PR DESCRIPTION
Pillow [removed `jpeg` as a dependency](https://github.com/Homebrew/homebrew-core/pull/106801), the bottle needs to be rebuilt to get rid of it here.

Seems to cause issues when trying to install, `brew linkage` reports:
```
Broken dependencies:
  /usr/local/opt/jpeg/lib/libjpeg.9.dylib (jpeg)
```
