### PR TITLE
Added pkg-config as dependency

### DIFF
--- a/Formula/qmk.rb
+++ b/Formula/qmk.rb
@@ -25,6 +25,7 @@ class Qmk < Formula
   depends_on "pillow"
   depends_on "python"
   depends_on "teensy_loader_cli"
+  depends_on "pkg-config"
 
   resource "appdirs" do
     url "https://files.pythonhosted.org/packages/d7/d8/05696357e0311f5b5c316d7b95f46c669dd9c15aaeecbb48c7d0aeb88c40/appdirs-1.4.4.tar.gz"

--- a/Formula/qmk.rb
+++ b/Formula/qmk.rb
@@ -5,12 +5,14 @@ class Qmk < Formula
   homepage "https://docs.qmk.fm/"
   url "https://files.pythonhosted.org/packages/52/4a/27caeef7f15316271adaf9d3f03390869be85fd72fbbed950137a5a50900/qmk-1.1.1.tar.gz"
   sha256 "dd028e09ebcd61f8bdf8cb82929dfafc0e007d97a5a3803b45819b4641773269"
+  revision 1
 
   bottle do
     root_url "https://github.com/qmk/homebrew-qmk/releases/download/qmk-1.1.1"
     sha256 cellar: :any, catalina: "d9369075d2786f5f3d39c59596b5e75870ce1630ff8a8f28ddbd6585ab5d1546"
   end
 
+  depends_on "pkg-config" => :build
   depends_on "avrdude"
   depends_on "bootloadhid"
   depends_on "clang-format"
@@ -25,7 +27,6 @@ class Qmk < Formula
   depends_on "pillow"
   depends_on "python"
   depends_on "teensy_loader_cli"
-  depends_on "pkg-config"
 
   resource "appdirs" do
     url "https://files.pythonhosted.org/packages/d7/d8/05696357e0311f5b5c316d7b95f46c669dd9c15aaeecbb48c7d0aeb88c40/appdirs-1.4.4.tar.gz"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

In my environment, Pillow is failed to install like the log pasted below. To solve it, I added pkg-config as a runtime dependency.

## Environment

- Mac mini (M1, 2020)
- Ventura 13.2
- `arch` -> arm64 (no rosetta)

## cf.

[Reddit post I referred to](https://www.reddit.com/r/ErgoMechKeyboards/comments/10aay3q/comment/j53pc5j)

> [monfresh](https://www.reddit.com/user/monfresh/)
> So, I uninstalled and reinstalled Homebrew on a spare M1 Mini that I use for testing my Mac setup scripts, and I was able to reproduce the issue. Then I ran my "Ruby on Mac" script, which installs several tools, and I was able to install qmk.
> Then I tried to narrow it down by uninstalling and reinstalling certain things, and I believe the key to a successful installation is pkg-config.
> Can you try brew install pkg-config, and then brew install qmk/qmk/qmk to see if that works now?

## Log

<details>
<summary>Log</summary>
<pre><code>
==> Tapping qmk/qmk
Cloning into '/opt/homebrew/Library/Taps/qmk/homebrew-qmk'...
remote: Enumerating objects: 354, done.
remote: Counting objects: 100% (53/53), done.
remote: Compressing objects: 100% (31/31), done.
remote: Total 354 (delta 28), reused 36 (delta 20), pack-reused 301
Receiving objects: 100% (354/354), 60.66 KiB | 6.07 MiB/s, done.
Resolving deltas: 100% (205/205), done.
Tapped 3 formulae (20 files, 88.5KB).
==> Tapping osx-cross/arm
Cloning into '/opt/homebrew/Library/Taps/osx-cross/homebrew-arm'...
remote: Enumerating objects: 259, done.
remote: Counting objects: 100% (109/109), done.
remote: Compressing objects: 100% (66/66), done.
remote: Total 259 (delta 50), reused 87 (delta 42), pack-reused 150
Receiving objects: 100% (259/259), 61.26 KiB | 6.13 MiB/s, done.
Resolving deltas: 100% (89/89), done.
Tapped 8 formulae (23 files, 104.6KB).
==> Tapping osx-cross/avr
Cloning into '/opt/homebrew/Library/Taps/osx-cross/homebrew-avr'...
remote: Enumerating objects: 1585, done.
remote: Counting objects: 100% (430/430), done.
remote: Compressing objects: 100% (155/155), done.
remote: Total 1585 (delta 296), reused 395 (delta 269), pack-reused 1155
Receiving objects: 100% (1585/1585), 352.80 KiB | 10.08 MiB/s, done.
Resolving deltas: 100% (1029/1029), done.
Tapped 10 formulae (31 files, 616.7KB).
==> Fetching dependencies for qmk/qmk/qmk: hidapi, icu4c, xz, lz4, zstd, boost, confuse, libusb, libftdi, libusb-compat, avrdude, bootloadhid, clang-format, dfu-programmer, dfu-util, make, mdloader, osx-cross/arm/arm-gcc-bin@8, m4, autoconf, automake, texinfo, avr-binutils, gmp, isl, mpfr, libmpc, osx-cross/avr/avr-gcc@8, jpeg-turbo, libimagequant, libpng, freetype, fribidi, fontconfig, pcre2, gettext, glib, xorgproto, libxau, libxdmcp, libxcb, libx11, libxext, libxrender, lzo, pixman, cairo, graphite2, harfbuzz, libraqm, libtiff, little-cms2, openjpeg, ca-certificates, openssl@1.1, tcl-tk, giflib, webp, pillow, gdbm, mpdecimal, readline, sqlite, python and teensy_loader_cli
==> Fetching hidapi
==> Downloading https://ghcr.io/v2/homebrew/core/hidapi/manifests/0.13.1
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/3ba69772b33b2127451b8bb28f5ca54e8cbe7b773a00af14207ac750810cbd81--hidapi-0.13.1.bottle_manifest.json
==> Downloading https://ghcr.io/v2/homebrew/core/hidapi/blobs/sha256:5aea99e710bcf73d1fac8accd3e9a09b89371e01a4af2a82a24805a49dfb0a2b
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/40ea8a743d807813f3092a7902dced13f57e60645796043ae3fc1f1cab9d16aa--hidapi--0.13.1.arm64_ventura.bottle.tar.gz
==> Fetching icu4c
==> Downloading https://ghcr.io/v2/homebrew/core/icu4c/manifests/72.1
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/adaa2fd48ef337b5bfee51ed8902dab61120bb41bd18f98eb20e744fdd5548c1--icu4c-72.1.bottle_manifest.json
==> Downloading https://ghcr.io/v2/homebrew/core/icu4c/blobs/sha256:0666e999875e81eadd009af55007c95cda37c7234acc12eb85cf42177984c699
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/b5387eff20f2e005df75fb220c2329237da248d0e23fcebd7f2227dad21d27e8--icu4c--72.1.arm64_ventura.bottle.tar.gz
==> Fetching xz
==> Downloading https://ghcr.io/v2/homebrew/core/xz/manifests/5.4.1
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/50832bf13dbc3fee17aae88a9a1b882971b78b8ae6377608d664d7b3eb5f2314--xz-5.4.1.bottle_manifest.json
==> Downloading https://ghcr.io/v2/homebrew/core/xz/blobs/sha256:26ede511c3cc726f939dd2f61b7e6798409c86b62be4678f008a12d515584efb
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/39ec5af2e89811503c1164a2ebbf12601c2b4bad117d93dac404b9f05550824a--xz--5.4.1.arm64_ventura.bottle.tar.gz
==> Fetching lz4
==> Downloading https://ghcr.io/v2/homebrew/core/lz4/manifests/1.9.4
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/379e59b981667f9585b33a2ff318769d8edca3ce6fd2e9a67ed291ae3e0cc872--lz4-1.9.4.bottle_manifest.json
==> Downloading https://ghcr.io/v2/homebrew/core/lz4/blobs/sha256:cd29e40287b0a2d665a647acbea5512e8db4c371687147aab5c60bf9059b2cca
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/bdbca4231a01d687e54f87627b47f5209cd836fcba5f58353597bb599bea9cbe--lz4--1.9.4.arm64_ventura.bottle.tar.gz
==> Fetching zstd
==> Downloading https://ghcr.io/v2/homebrew/core/zstd/manifests/1.5.2-3
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/f1226cb81ee54df46f1bb53da8118ca107a4f229ac63dc9405f2519c9f6fb45e--zstd-1.5.2-3.bottle_manifest.json
==> Downloading https://ghcr.io/v2/homebrew/core/zstd/blobs/sha256:92f953ed8a8c77b9e282d7cb6a6288d77e6f40bb1b3eec78e2fbbae29c12b220
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/893cae214d78e425489725f69f44aac6b1932784c93ccea84256a7df3bf75d49--zstd--1.5.2.arm64_ventura.bottle.3.tar.gz
==> Fetching boost
==> Downloading https://ghcr.io/v2/homebrew/core/boost/manifests/1.81.0_1
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/8d79ba33b2820584f37a08164c2e12a409c2915b01fbe52c3d71f4d8a50a808f--boost-1.81.0_1.bottle_manifest.json
==> Downloading https://ghcr.io/v2/homebrew/core/boost/blobs/sha256:8a4a21f28eea820cdfb2ca94d6a9c2ecad40592b145de06698283dc3c7ae0eeb
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/21e5440723410b9c5725a2c6a0169e97889d8fb15839322e57eea9369c6cb192--boost--1.81.0_1.arm64_ventura.bottle.tar.gz
==> Fetching confuse
==> Downloading https://ghcr.io/v2/homebrew/core/confuse/manifests/3.3
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/a09f514665c87141e6f2fd437ab609993f206ef00910cea28201e52a918329bf--confuse-3.3.bottle_manifest.json
==> Downloading https://ghcr.io/v2/homebrew/core/confuse/blobs/sha256:1c7aa3d075082f2742747ac5034f60c90b448c694ccc5b3330b71f1afdd81f81
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/a2cebb43fc123a1a2c4843951eb44fdc4e13fdec97c1ef2d1ec3946a51645de6--confuse--3.3.arm64_ventura.bottle.tar.gz
==> Fetching libusb
==> Downloading https://ghcr.io/v2/homebrew/core/libusb/manifests/1.0.26
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/ce7ffd7c94deb7060c2cac56f1d68a97b9d4bdc039f9548c3df327bee3d20ae4--libusb-1.0.26.bottle_manifest.json
==> Downloading https://ghcr.io/v2/homebrew/core/libusb/blobs/sha256:ea8a4a04b5cc81eff38d0c5cdfe2fbac519ca2c7652c64371074f4abaf766a0b
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/aa83a0282204f89d598f699c1b5f78056b57f40bbaae5de168a953568458353e--libusb--1.0.26.arm64_ventura.bottle.tar.gz
==> Fetching libftdi
==> Downloading https://ghcr.io/v2/homebrew/core/libftdi/manifests/1.5_2
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/d7dd754a416715375d46e69a69b46cf756740bfd46a279c9d32b8abc20008e0a--libftdi-1.5_2.bottle_manifest.json
==> Downloading https://ghcr.io/v2/homebrew/core/libftdi/blobs/sha256:db8777d9eec5f36b23b191183c6d25c398484c09b2ca5833d5ef252ef5ce7bfd
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/ca65fa5c6d9b3b9c4b00d9539f6e4c63e834330a2741fce76f6266db141a5435--libftdi--1.5_2.arm64_ventura.bottle.tar.gz
==> Fetching libusb-compat
==> Downloading https://ghcr.io/v2/homebrew/core/libusb-compat/manifests/0.1.8
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/97cdaf71751ad6b19f122ad3956d4d52b173b275b7120711c70349ae794c2ee6--libusb-compat-0.1.8.bottle_manifest.json
==> Downloading https://ghcr.io/v2/homebrew/core/libusb-compat/blobs/sha256:f166717b7947442be0d3dd9f4f32af5a81dc1b88e33c1e6d255f3661f1c9b00c
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/ffa37848fd05e106d4c050733a22ce6b12c27dac03814364e8d47c1424ebbc4c--libusb-compat--0.1.8.arm64_ventura.bottle.tar.gz
==> Fetching avrdude
==> Downloading https://ghcr.io/v2/homebrew/core/avrdude/manifests/7.0_2
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/78e02371cdcf49288c566045a40106818630bc2b0dece52d714fcde190b75788--avrdude-7.0_2.bottle_manifest.json
==> Downloading https://ghcr.io/v2/homebrew/core/avrdude/blobs/sha256:50c20fe810d534c1c4cea3209ca812d35167c4b51e140f7154d96563d9e397e0
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/def74d8d771beaa021cc7e41f597efd71317c126f42df8772aa9a9eafad87a33--avrdude--7.0_2.arm64_ventura.bottle.tar.gz
==> Fetching bootloadhid
==> Downloading https://ghcr.io/v2/homebrew/core/bootloadhid/manifests/2012-12-08
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/10ccd43aa9f606db1d1139c6a0a7fe4fa14ff50b0af6a8631f491901ccd2c37b--bootloadhid-2012-12-08.bottle_manifest.json
==> Downloading https://ghcr.io/v2/homebrew/core/bootloadhid/blobs/sha256:2abf7dd9ed6601a8f2f42073b64abb33d20f7e81fdfd9d296f5441987d2054fe
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/284def9e2afc1b7695be17facf07381408bf86bb2755506bf4e027d27859d83a--bootloadhid--2012-12-08.arm64_ventura.bottle.tar.gz
==> Fetching clang-format
==> Downloading https://ghcr.io/v2/homebrew/core/clang-format/manifests/15.0.7
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/d5012a2e1b4663a5c87c86983664aa642ff353cb719658349878f3ffcf74c29e--clang-format-15.0.7.bottle_manifest.json
==> Downloading https://ghcr.io/v2/homebrew/core/clang-format/blobs/sha256:f272332a2b75d4b2e6a51d4832a848a598b923b4c6dc14568f004ec1f8fda6a5
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/37249ceffc8d4f3975d696fb016d91f1b90866b24a935b0b7d94c431a25eeddc--clang-format--15.0.7.arm64_ventura.bottle.tar.gz
==> Fetching dfu-programmer
==> Downloading https://ghcr.io/v2/homebrew/core/dfu-programmer/manifests/0.7.2
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/d34d2fa6a9e44bcff3883a53df253eb4f42ce1c4a49d64fb7991aca55df2b10e--dfu-programmer-0.7.2.bottle_manifest.json
==> Downloading https://ghcr.io/v2/homebrew/core/dfu-programmer/blobs/sha256:9f41045987af7f7daa4470dcb37de69a210e4ccb6bc5f8e9b4d5d2bf310ec562
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/951fb800377285a7ae7c792bd5590090ac86e91b9fb5be5f6eb36a54b27a172a--dfu-programmer--0.7.2.arm64_ventura.bottle.tar.gz
==> Fetching dfu-util
==> Downloading https://ghcr.io/v2/homebrew/core/dfu-util/manifests/0.11
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/e5b1bd8ea1bd2ccd8c5aaf4bdcbdc2eed5394dcfe6bec9c06a84994cb5c8a993--dfu-util-0.11.bottle_manifest.json
==> Downloading https://ghcr.io/v2/homebrew/core/dfu-util/blobs/sha256:03e81fc129ada62759e3cd8d892131ca326851ab6631730e9d101405c0e2594d
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/9082167e1f50982605a7db16fd8b939c65a7777b4e199bbfd4dbbbd06ae8a846--dfu-util--0.11.arm64_ventura.bottle.tar.gz
==> Fetching make
==> Downloading https://ghcr.io/v2/homebrew/core/make/manifests/4.4
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/24cde5b6cbb99314c3ae1535fba5436bf4a5c230829157600b6fbec1b6fa5a0a--make-4.4.bottle_manifest.json
==> Downloading https://ghcr.io/v2/homebrew/core/make/blobs/sha256:1eed07bf3c2d4521eb70271a5ef7be75a8d3401f9d1301a7a2925f217375bd5b
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/3965a70785f6da716c82d5fd05aeed5740ce15ea09cd1ce9dd4cf074e904da39--make--4.4.arm64_ventura.bottle.tar.gz
==> Fetching qmk/qmk/mdloader
==> Downloading https://github.com/Massdrop/mdloader/archive/1.0.7.tar.gz
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/1c3ac50eb4f548f27a6ab96c9b5932313770755dddbfb98ab02efbc2cda95fc0--mdloader-1.0.7.tar.gz
==> Fetching osx-cross/arm/arm-gcc-bin@8
==> Downloading https://developer.arm.com/-/media/Files/downloads/gnu-rm/8-2019q3/RC1.1/gcc-arm-none-eabi-8-2019-q3-update-mac.tar.bz2
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/f9950d131d3245cda9fa893e0cd38c68a524d8f263e980801f9d4ca164a70be7--gcc-arm-none-eabi-8-2019-q3-update-mac.tar.bz2
==> Fetching m4
==> Downloading https://ghcr.io/v2/homebrew/core/m4/manifests/1.4.19
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/5b2a7f715487b7377e409e8ca58569040cd89f33859f691210c58d94410fd33b--m4-1.4.19.bottle_manifest.json
==> Downloading https://ghcr.io/v2/homebrew/core/m4/blobs/sha256:11308abe8d607be35da9e88a1d789f191914bf043bca4fdde2b50a6cbf1713cc
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/1752fb95f551f448b0a035c6e91ba65592be0cc30a526e880c2241d361e39bd8--m4--1.4.19.arm64_ventura.bottle.tar.gz
==> Fetching autoconf
==> Downloading https://ghcr.io/v2/homebrew/core/autoconf/manifests/2.71
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/057cde2b686872aeeff2e91dc36d037807d7342dd50929fbdfea8bcc572fbed0--autoconf-2.71.bottle_manifest.json
==> Downloading https://ghcr.io/v2/homebrew/core/autoconf/blobs/sha256:a3d366c98b0da7a0a4f352eef49af9d612ac7aea4ffe420d49ff12bd90007415
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/7613e266193af4c54b2933e9cd512ec386425ef0f959ca0a802af833cafb2474--autoconf--2.71.arm64_ventura.bottle.tar.gz
==> Fetching automake
==> Downloading https://ghcr.io/v2/homebrew/core/automake/manifests/1.16.5
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/6863d3ffa73c5a5cbf1f1ea9e47b60784d09b232ac9e56149c1b931d9ec44d8b--automake-1.16.5.bottle_manifest.json
==> Downloading https://ghcr.io/v2/homebrew/core/automake/blobs/sha256:f68481d06be7fa3f0a0881edb825a336e7f6548191c762d68bd817183b238f5a
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/cbd9fb298ac58ddd98b7d9b90bf3c2957d0feca6f850d40c33fe3ce714ec5ada--automake--1.16.5.arm64_ventura.bottle.tar.gz
==> Fetching texinfo
==> Downloading https://ghcr.io/v2/homebrew/core/texinfo/manifests/7.0.2
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/12a374307fdb2d1d3b948246fa81f4eb65b429be59a518b9427a84a78a25ed1c--texinfo-7.0.2.bottle_manifest.json
==> Downloading https://ghcr.io/v2/homebrew/core/texinfo/blobs/sha256:85b1f14167d0b7eaf65a5be395f5d3a75d27e3182243c775d9cd1929c96a36df
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/8acd7e519994ff7b05481b955488799318cf14c6aac2747afbf3784df5a78926--texinfo--7.0.2.arm64_ventura.bottle.tar.gz
==> Fetching osx-cross/avr/avr-binutils
==> Downloading https://raw.githubusercontent.com/archlinux/svntogit-community/c3efadcb76f4d8b1a3784015e7c472f59dbfa7de/avr-binutils/repos/community-x86_64/avr-size.patch
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/6d34565d13f9b0ff6a9e06e80fb5c34787ea005b5edf5ce99ece2ff5bef3b069--avr-size.patch
==> Downloading https://raw.githubusercontent.com/osx-cross/homebrew-avr/18d50ba2a168a3b90a25c96e4bc4c053df77d7dc/Patch/avr-binutils-elf-bfd-gdb-fix.patch
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/0ca5d8e65886bc674f0ba0ec9f98e4b657920f87f9784a16f9fca756681475b3--avr-binutils-elf-bfd-gdb-fix.patch
==> Downloading https://ftp.gnu.org/gnu/binutils/binutils-2.40.tar.xz
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/c7a3087962535ba0925d6c3592fada220e23b7321fa3a6c12661bc9ee0a6f377--binutils-2.40.tar.xz
==> Fetching gmp
==> Downloading https://ghcr.io/v2/homebrew/core/gmp/manifests/6.2.1_1
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/a1986a80dafb4e42b8372268a00d8d14aa8294154c876ba82e7ce48db06885cb--gmp-6.2.1_1.bottle_manifest.json
==> Downloading https://ghcr.io/v2/homebrew/core/gmp/blobs/sha256:2436cd120e5678d67c24020a50cbbf7c0220e7ecaac63981335872b9d666bcad
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/46826e3c59f848f0af2a8d8601b1de182ad9406c3bcead28c60213dd2d33ee0e--gmp--6.2.1_1.arm64_ventura.bottle.tar.gz
==> Fetching isl
==> Downloading https://ghcr.io/v2/homebrew/core/isl/manifests/0.25
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/ab8f0cce52620f47320ff6c28ff1f404a8632c53e8ab21e349952ed856012166--isl-0.25.bottle_manifest.json
==> Downloading https://ghcr.io/v2/homebrew/core/isl/blobs/sha256:93e737d38d526bb8e78379124c237b3a532c2c8a77562dcf178baa955b193a97
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/97d41542b52daf44c97184def02eb033dd0dcafb848af1b9369e4afbb1eb0fe0--isl--0.25.arm64_ventura.bottle.tar.gz
==> Fetching mpfr
==> Downloading https://ghcr.io/v2/homebrew/core/mpfr/manifests/4.2.0
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/4de750845103fe10e75457c71db4816601a091134ad6f4356797446dae1bf08f--mpfr-4.2.0.bottle_manifest.json
==> Downloading https://ghcr.io/v2/homebrew/core/mpfr/blobs/sha256:e8d923fe4d12887beeb011b2486890d9fd7bf13a821bab1adb4932edd7b5a802
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/9b1fb3a64353987a39fb8c729b75e63f357f8650ebbf619b9cd1b89033a37583--mpfr--4.2.0.arm64_ventura.bottle.tar.gz
==> Fetching libmpc
==> Downloading https://ghcr.io/v2/homebrew/core/libmpc/manifests/1.3.1
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/fdfa98e0f8bb3ce075cb32776ac2345aa2f89252706c162aecfc841085fa76be--libmpc-1.3.1.bottle_manifest.json
==> Downloading https://ghcr.io/v2/homebrew/core/libmpc/blobs/sha256:da4ff781bc469c82af17f98f0bdbf20932e222d0520ab784cd1b322b789ad7a5
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/fb60160bad0c3f9edaf333490bbe6af401806de84ec08562856555011b4085d5--libmpc--1.3.1.arm64_ventura.bottle.tar.gz
==> Fetching osx-cross/avr/avr-gcc@8
==> Downloading https://gist.githubusercontent.com/DavidEGrayson/88bceb3f4e62f45725ecbb9248366300/raw/c1f515475aff1e1e3985569d9b715edb0f317648/gcc-11-arm-darwin.patch
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/def654fc009e1286443dbc4e1baa98eeeaee383d419d8a1d15200ab895520379--gcc-11-arm-darwin.patch
==> Downloading https://download.savannah.gnu.org/releases/avr-libc/avr-libc-2.1.0.tar.bz2
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/82989e2eb60e70483e667482e25d205685a09019a1c993b99a467ad14d3bb2d0--avr-libc-2.1.0.tar.bz2
==> Downloading https://ftp.gnu.org/gnu/gcc/gcc-8.5.0/gcc-8.5.0.tar.xz
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/f2092ba5952c9c44d95063a07d4661fab20de4703b728a8dddefd5a4387e90d0--gcc-8.5.0.tar.xz
==> Fetching jpeg-turbo
==> Downloading https://ghcr.io/v2/homebrew/core/jpeg-turbo/manifests/2.1.4
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/3f8a9083cce3533af8c64d8ddacc9dfa2efd55703d44b226b7c5214e7575a794--jpeg-turbo-2.1.4.bottle_manifest.json
==> Downloading https://ghcr.io/v2/homebrew/core/jpeg-turbo/blobs/sha256:692e1da07f1d20df3d8157bee3b15c37d53fdd04b6d5de754f0841a3915ab1ab
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/5fa4b69320fbb62fd44bfb888fd918fe2a68789b6d5b7d8072c2488ede5b61bc--jpeg-turbo--2.1.4.arm64_ventura.bottle.tar.gz
==> Fetching libimagequant
==> Downloading https://ghcr.io/v2/homebrew/core/libimagequant/manifests/4.1.0
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/afdbe2cda4bfc2f6799a683bf3c817cbacbed9258390d841f8000122c07997d5--libimagequant-4.1.0.bottle_manifest.json
==> Downloading https://ghcr.io/v2/homebrew/core/libimagequant/blobs/sha256:83b8ea0a2654c6a2516712ece9e20208770ff90fa324e03997d1fe8b0f65871e
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/a9ed1208629ab879ba94291ae582aadb37a9c18e8fae8e528929cac9f19e4f7e--libimagequant--4.1.0.arm64_ventura.bottle.tar.gz
==> Fetching libpng
==> Downloading https://ghcr.io/v2/homebrew/core/libpng/manifests/1.6.39
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/7d87285418cf2481c559b19433f1a0c0d5117b0b7b302f8829a798d8730a8556--libpng-1.6.39.bottle_manifest.json
==> Downloading https://ghcr.io/v2/homebrew/core/libpng/blobs/sha256:5fcb6945c7fe220f8b983c18edd7a42d8d84a9d62696b4fec001c1697300fb61
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/e32f180ed45feb68fa9a81fcd47a14e455d898251281904dbc7233b2afc60d53--libpng--1.6.39.arm64_ventura.bottle.tar.gz
==> Fetching freetype
==> Downloading https://ghcr.io/v2/homebrew/core/freetype/manifests/2.12.1
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/908428437764929aa268ec3967d2d4c58d2c0cdcb971555c98cd45ab6b7e3368--freetype-2.12.1.bottle_manifest.json
==> Downloading https://ghcr.io/v2/homebrew/core/freetype/blobs/sha256:f91e2b53f5f3753508ba81d17a01974285b90696033053837fbe20aac876883f
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/125fbddee3a1f447ed0dbd14f2841920882cf5902aa21d6dbd29469f38582e98--freetype--2.12.1.arm64_ventura.bottle.tar.gz
==> Fetching fribidi
==> Downloading https://ghcr.io/v2/homebrew/core/fribidi/manifests/1.0.12
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/43df59a54cb64e3d6de7c967b4b3fbb01989512758bffd8e681dcf9347a8a34f--fribidi-1.0.12.bottle_manifest.json
==> Downloading https://ghcr.io/v2/homebrew/core/fribidi/blobs/sha256:98d26d50c4443a28950bdedc0fac9a708feb6e79e5f42e9c0622e133381c0056
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/bf73bfc1ef71570ebe3faa4db2491727eb8b07e857c510ea00459ae65c3ec2ca--fribidi--1.0.12.arm64_ventura.bottle.tar.gz
==> Fetching fontconfig
==> Downloading https://ghcr.io/v2/homebrew/core/fontconfig/manifests/2.14.2
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/661b3d30dc143679f93265d36ce47323212b212b53bb099e319b0dba9c05594e--fontconfig-2.14.2.bottle_manifest.json
==> Downloading https://ghcr.io/v2/homebrew/core/fontconfig/blobs/sha256:11cd488fc519d98142ed747300546eb65976c9a3bc973d955a934741c609b5df
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/f7408eb81fd9b82030c57ca47c54bd3f79a905a99043960c3ccbde48e0c00b5c--fontconfig--2.14.2.arm64_ventura.bottle.tar.gz
==> Fetching pcre2
==> Downloading https://ghcr.io/v2/homebrew/core/pcre2/manifests/10.42
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/6a53794fcaabc5cc5e05b19c02ca9c4c5f2cb9a4d65a5790a6841146465b040f--pcre2-10.42.bottle_manifest.json
==> Downloading https://ghcr.io/v2/homebrew/core/pcre2/blobs/sha256:8423a338c590ab1a6f265b39a9d1a67ab1361a586f0e494a8c9555cff2867536
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/20ad76b6ed64ec2235a96dfdd8b8b933d84eb616a5b9c2cd8b94768eabe220f5--pcre2--10.42.arm64_ventura.bottle.tar.gz
==> Fetching gettext
==> Downloading https://ghcr.io/v2/homebrew/core/gettext/manifests/0.21.1
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/1c2f2c62faee672530e8e8e2695f99d26d1b606e74b289d1914dfa13c732c500--gettext-0.21.1.bottle_manifest.json
==> Downloading https://ghcr.io/v2/homebrew/core/gettext/blobs/sha256:28c5b06e66800aa2d460336d001379e35e664310d12638de35a1b0f2b9a44913
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/e802c20093535dc4a2cb11b0279b8c26f8c920746bd2fdcddcd50faf461f7c3f--gettext--0.21.1.arm64_ventura.bottle.tar.gz
==> Fetching glib
==> Downloading https://ghcr.io/v2/homebrew/core/glib/manifests/2.74.5
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/35e2321bdf789440a78d6bb6ae383a7ca1e0c48997a5356d05c94a91d8f6a531--glib-2.74.5.bottle_manifest.json
==> Downloading https://ghcr.io/v2/homebrew/core/glib/blobs/sha256:dbc8e8fdf0da9f4df7b4a3f576dd55ec4fc7504b71dbdfebaf4c380cb556815b
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/0eb58575f9374924f2e6765590c5bb04fa63651bd3937cbfbbf8292cd8e987b9--glib--2.74.5.arm64_ventura.bottle.tar.gz
==> Fetching xorgproto
==> Downloading https://ghcr.io/v2/homebrew/core/xorgproto/manifests/2022.2
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/9d0741febb29dfbb4f0e845adaa75d44fa0f9498bd1862f77d52561a8cb87300--xorgproto-2022.2.bottle_manifest.json
==> Downloading https://ghcr.io/v2/homebrew/core/xorgproto/blobs/sha256:d6deb2e4712bdd55eadfdcd7156814a6c42c9d94eb5cda72b89c9e4221a8a99d
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/3d716cdc6955831613e02fb92d11ae81ba05df7ea0153f2e633a6b7834898dc2--xorgproto--2022.2.arm64_ventura.bottle.tar.gz
==> Fetching libxau
==> Downloading https://ghcr.io/v2/homebrew/core/libxau/manifests/1.0.11
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/7faff26297b2e07682655beaa529cff7b3de0ad1abc013863ca3d03602b79ee7--libxau-1.0.11.bottle_manifest.json
==> Downloading https://ghcr.io/v2/homebrew/core/libxau/blobs/sha256:d8cc440c5804ecf424d96d3cd4e92e88c83d43e7f927126c768caee2dffe36a8
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/a1f8411236b667139ee1ecc1a4802559f26ff128c1b693516ca2ac8f9d2a3413--libxau--1.0.11.arm64_ventura.bottle.tar.gz
==> Fetching libxdmcp
==> Downloading https://ghcr.io/v2/homebrew/core/libxdmcp/manifests/1.1.4
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/1af80edced252b5f690f78a3805b785cbf689dc947cd5f45dced60c97640a9c9--libxdmcp-1.1.4.bottle_manifest.json
==> Downloading https://ghcr.io/v2/homebrew/core/libxdmcp/blobs/sha256:2fb2d55b8f9722e68eeb76bcd77d3e9d5bbe52c96db2c05ceb70152f0ff4883d
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/7167772f3e11cc89a6e578d955ee39fa57cfc0f160bb8812f56dac6fbde59246--libxdmcp--1.1.4.arm64_ventura.bottle.tar.gz
==> Fetching libxcb
==> Downloading https://ghcr.io/v2/homebrew/core/libxcb/manifests/1.15-2
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/2a03b564f5bf826409537340998275531408c914e311e9eb031f9642f3bd0402--libxcb-1.15-2.bottle_manifest.json
==> Downloading https://ghcr.io/v2/homebrew/core/libxcb/blobs/sha256:2a2826a150a07d7cb11afc60822d235156f4b0e26fce2b40127aa427c1d702d5
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/c1d866f28662d35b0395548e4002a442440dda8898c7ebc679d03488283acb7f--libxcb--1.15.arm64_ventura.bottle.2.tar.gz
==> Fetching libx11
==> Downloading https://ghcr.io/v2/homebrew/core/libx11/manifests/1.8.3
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/67ef12ca0e3bcdbd6d11db4f5dfd9c80922ff1b81313073ff4a8650e5b65a2a6--libx11-1.8.3.bottle_manifest.json
==> Downloading https://ghcr.io/v2/homebrew/core/libx11/blobs/sha256:7371880b0132555d489372a030da8d7729f5e9d616cfe7bf85eaf96582e009dc
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/6f681e9465ec7e452f4a94cccb4b07165fb951fc03e8deaaed26a1e5834bbde5--libx11--1.8.3.arm64_ventura.bottle.tar.gz
==> Fetching libxext
==> Downloading https://ghcr.io/v2/homebrew/core/libxext/manifests/1.3.5
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/36b14aebd45b8fbf0f965d846bbc5126adbe882c0775c9936edb0432b347b9a1--libxext-1.3.5.bottle_manifest.json
==> Downloading https://ghcr.io/v2/homebrew/core/libxext/blobs/sha256:36ef5333565be1614ad8eb2d740ea93df80c5d2ee41b403145179e7c5d1e1e82
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/f4c84f25a99b1eae8afd8436f9c47f3a4806aa9ecc36a7dbb9cdf5d32fe0d151--libxext--1.3.5.arm64_ventura.bottle.tar.gz
==> Fetching libxrender
==> Downloading https://ghcr.io/v2/homebrew/core/libxrender/manifests/0.9.11
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/134c11be8346a1b116e04983c2da6366f29c4f4c2abc17604dcdb80d0475ae9d--libxrender-0.9.11.bottle_manifest.json
==> Downloading https://ghcr.io/v2/homebrew/core/libxrender/blobs/sha256:510d0cd0f72480d716b38cd935e3a334ed1be972210ffac7309d0dd80469c8bb
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/cf4e6f27b41ee48304dfa7f1d20e9d72b3eac55c61bb7ab02360c9b46df078f1--libxrender--0.9.11.arm64_ventura.bottle.tar.gz
==> Fetching lzo
==> Downloading https://ghcr.io/v2/homebrew/core/lzo/manifests/2.10
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/d4aa5b0c239912c53bc857d1012c6b7feb4acb509618f5e100f95bf8521f08e7--lzo-2.10.bottle_manifest.json
==> Downloading https://ghcr.io/v2/homebrew/core/lzo/blobs/sha256:a565c627b13f2dc7fc4550aa8290a4c3feb2f48fcaa45c9f7f4bc4fe4535aa66
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/b859e0c335f31f15545d4cf698238a5ca6a91e4fccc88bda29d2763941acf9a6--lzo--2.10.arm64_ventura.bottle.tar.gz
==> Fetching pixman
==> Downloading https://ghcr.io/v2/homebrew/core/pixman/manifests/0.42.2
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/602e44a110e6f967b5cfe6d79dd70688902fd411336d18ad05ef992a90aa7a4b--pixman-0.42.2.bottle_manifest.json
==> Downloading https://ghcr.io/v2/homebrew/core/pixman/blobs/sha256:f98b74948d7fa6edc00158c63c02de8f9c58276efb076ab1d6e740ef061f8dee
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/0d8ebf45d80d3bfbadd97677d94a9b798713c9fb7c025a8010c12d2de4777036--pixman--0.42.2.arm64_ventura.bottle.tar.gz
==> Fetching cairo
==> Downloading https://ghcr.io/v2/homebrew/core/cairo/manifests/1.16.0_5
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/f9e86ee818c57a136b1c1c82caecdf07bb8eaad8e31f5e59e456a10d6d1a1cc5--cairo-1.16.0_5.bottle_manifest.json
==> Downloading https://ghcr.io/v2/homebrew/core/cairo/blobs/sha256:4a0f5f55a3314f6b4223661c3af406d3551349b4dcabfda7a6e7b6a569187764
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/d2b099dbaabd6975ebf10144287691e611ff445acfd25a95787f9aa5c238064b--cairo--1.16.0_5.arm64_ventura.bottle.tar.gz
==> Fetching graphite2
==> Downloading https://ghcr.io/v2/homebrew/core/graphite2/manifests/1.3.14
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/bbb4dd2ef1846301d1eb08053e19e11ca9c780f93f4d3b2d638fd94a9bf54a0c--graphite2-1.3.14.bottle_manifest.json
==> Downloading https://ghcr.io/v2/homebrew/core/graphite2/blobs/sha256:3ec770419ed60d211670f73bf078512824151b460c5c37740ee8b83e3dbb8357
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/9f2bba1173f565d3d7ef1ab53da317f9a8b737a7f47f0a71d58c0ddec1e7f899--graphite2--1.3.14.arm64_ventura.bottle.tar.gz
==> Fetching harfbuzz
==> Downloading https://ghcr.io/v2/homebrew/core/harfbuzz/manifests/6.0.0_1
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/23bde2902b8c68f92c86128d4e1b4e429bc7b3ed06d59da254a8f01ee3000c59--harfbuzz-6.0.0_1.bottle_manifest.json
==> Downloading https://ghcr.io/v2/homebrew/core/harfbuzz/blobs/sha256:469d30da77414cc94994cf99cb6c3d1809db910bc20433edca00523d00bd845f
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/aadd90e6bd0224e5c488e089465e1e0ba2025eca6779eb2f9fc14465cb7870fa--harfbuzz--6.0.0_1.arm64_ventura.bottle.tar.gz
==> Fetching libraqm
==> Downloading https://ghcr.io/v2/homebrew/core/libraqm/manifests/0.10.0
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/72d0fddc7ae3da7f68febcfca0ff2de7ddac1c28b57525048c6d3cddc8ac0e1a--libraqm-0.10.0.bottle_manifest.json
==> Downloading https://ghcr.io/v2/homebrew/core/libraqm/blobs/sha256:2113d8672e259d7b41f21f6bb724c8080f59f7a0fefea7da07cb4354b82823ab
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/be5c9af39e3f2d1cb5819532956b0fa2b861cea97df8a033823ea66b72e80d8d--libraqm--0.10.0.arm64_ventura.bottle.tar.gz
==> Fetching libtiff
==> Downloading https://ghcr.io/v2/homebrew/core/libtiff/manifests/4.4.0_1-1
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/045dd09de65fc836bebea86293526922ac74e8a456e721108460c2dc19495594--libtiff-4.4.0_1-1.bottle_manifest.json
==> Downloading https://ghcr.io/v2/homebrew/core/libtiff/blobs/sha256:4f8764b4cf388d7fdf727b2c61d1b48efb43ba4d337949bf34a932c08361681a
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/928077e2d0153a000e1fa6ba0c25def27896e6bf8a8b00978a818f1623e4ec91--libtiff--4.4.0_1.arm64_ventura.bottle.1.tar.gz
==> Fetching little-cms2
==> Downloading https://ghcr.io/v2/homebrew/core/little-cms2/manifests/2.14
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/80b5fe6f3594d3a3980e60bcef3a3479a20d05ec96378f3df8c6003ed86c50f3--little-cms2-2.14.bottle_manifest.json
==> Downloading https://ghcr.io/v2/homebrew/core/little-cms2/blobs/sha256:f65e0095a8a82a803ac26c5bbd5197032b8e744cc6f6361d992ee40d68174f1e
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/1e40d172a52d03f38e9032fed3faf2be3b1e3a615cd0eb793cea6bf444322db4--little-cms2--2.14.arm64_ventura.bottle.tar.gz
==> Fetching openjpeg
==> Downloading https://ghcr.io/v2/homebrew/core/openjpeg/manifests/2.5.0-1
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/181ab6026fe4071698a63df6d38c848c6d4857c25b7e9cc84e48631de219dfea--openjpeg-2.5.0-1.bottle_manifest.json
==> Downloading https://ghcr.io/v2/homebrew/core/openjpeg/blobs/sha256:46a9bf9f697e8e98a296cf25e3f6fc03d06c8814ad622b3d6e6cdf4df5ef4bd8
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/d032bc66215022be6b601626c7bf4bb64a32d9700f078b130f92e46118b18ebb--openjpeg--2.5.0.arm64_ventura.bottle.1.tar.gz
==> Fetching ca-certificates
==> Downloading https://ghcr.io/v2/homebrew/core/ca-certificates/manifests/2023-01-10
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/927414ed081d996b84d938be6af4d2639403b4d2bee3cc29268d0844999da180--ca-certificates-2023-01-10.bottle_manifest.json
==> Downloading https://ghcr.io/v2/homebrew/core/ca-certificates/blobs/sha256:11fe9d0a98a2ac454fa1db95762a697c3340f46560ff27e5e9db8fdeb003f17e
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/ca2448928ab98c455b5e46d4a6604247a151ab0f4e60553dbb5c6aecd2e1df3c--ca-certificates--2023-01-10.all.bottle.tar.gz
==> Fetching openssl@1.1
==> Downloading https://ghcr.io/v2/homebrew/core/openssl/1.1/manifests/1.1.1s
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/0bd540a808ade4448d977fc4dc9711d8ea9a9b36a677e29a00f8ef821f7be88b--openssl@1.1-1.1.1s.bottle_manifest.json
==> Downloading https://ghcr.io/v2/homebrew/core/openssl/1.1/blobs/sha256:3a7812321f40490623859b1c31644c6f3ba1b76c1ca7f780b9413b912e1b1415
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/e8543caa6f3e3171f22c63c8c0d13b610724889a6afa8fd27fb93e52c29d6274--openssl@1.1--1.1.1s.arm64_ventura.bottle.tar.gz
==> Fetching tcl-tk
==> Downloading https://ghcr.io/v2/homebrew/core/tcl-tk/manifests/8.6.13
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/853d99c56783beed5256c5c55971633869ce89dad0b94696b56d7180221f6051--tcl-tk-8.6.13.bottle_manifest.json
==> Downloading https://ghcr.io/v2/homebrew/core/tcl-tk/blobs/sha256:53300b4a5e2d7ef71b25b5ecb7b1b20ae435234dd114d2163e643d5857b1de21
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/d8c961516af6f837ac8648bc683dff270f0d902ee666d0b98f2e0fb016b9b842--tcl-tk--8.6.13.arm64_ventura.bottle.tar.gz
==> Fetching giflib
==> Downloading https://ghcr.io/v2/homebrew/core/giflib/manifests/5.2.1
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/51910e68b838a5c62c91c9352172d516e77a3c3c1a59a2cebaffc3f64f46adf4--giflib-5.2.1.bottle_manifest.json
==> Downloading https://ghcr.io/v2/homebrew/core/giflib/blobs/sha256:ced5a24b12f7057504aa8821a81c03c4d83ff6ba861487e25eba34b863237c20
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/5b08b896fd26dcbaf618db0a80e50fcdb4378ad1e9b292ccbe82d468a4b86713--giflib--5.2.1.arm64_ventura.bottle.tar.gz
==> Fetching webp
==> Downloading https://ghcr.io/v2/homebrew/core/webp/manifests/1.3.0
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/ff02a3b4855cce282bd060ddc2ebc168bb518214e27695910d0a9c0f814d4dc6--webp-1.3.0.bottle_manifest.json
==> Downloading https://ghcr.io/v2/homebrew/core/webp/blobs/sha256:fb2edf5a9f207f41aa11ff72efb0822da454f3a15e633738df8afdf69c40857d
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/e7e84322f8f53df2f6e0002e8f53e2b6e3bd7a08bf5c76f5bcb3079fcb53f6e6--webp--1.3.0.arm64_ventura.bottle.tar.gz
==> Fetching pillow
==> Downloading https://ghcr.io/v2/homebrew/core/pillow/manifests/9.4.0
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/30e9824435347a394b77810f01a68b3bc28c9e8e33c1d24255a779f600ed834c--pillow-9.4.0.bottle_manifest.json
==> Downloading https://ghcr.io/v2/homebrew/core/pillow/blobs/sha256:978764003b8b3af314360d4511779efc2f315f80258e7c778ea375163a1a81a9
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/2e545ba8b725372bd359a92499270fe76b95c7d8bc33a9979ffb1f7d288206f8--pillow--9.4.0.arm64_ventura.bottle.tar.gz
==> Fetching gdbm
==> Downloading https://ghcr.io/v2/homebrew/core/gdbm/manifests/1.23
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/ce78100f130177bffd255fda9df551477edd224a5080cb86cac12818954a7438--gdbm-1.23.bottle_manifest.json
==> Downloading https://ghcr.io/v2/homebrew/core/gdbm/blobs/sha256:a7321472cc9ff32a54c549556340dd1ad9dd95415828149005fb4959d04e83b7
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/ccbcc5f808a807e6f0d6efb823081e4154d625720baca9961d379c98bc18695b--gdbm--1.23.arm64_ventura.bottle.tar.gz
==> Fetching mpdecimal
==> Downloading https://ghcr.io/v2/homebrew/core/mpdecimal/manifests/2.5.1
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/f367c2ee08c56b88be0662703a8e4275f8657608a268c8c44e845154b0cea543--mpdecimal-2.5.1.bottle_manifest.json
==> Downloading https://ghcr.io/v2/homebrew/core/mpdecimal/blobs/sha256:5b1c62c08b42feb6e48c461a9de4751803f3ccc76830213a517f0905178dbbef
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/6bf6539627b31c17765f4bcfbe8be8996f3505d3342804531f114c13e64a5a9e--mpdecimal--2.5.1.arm64_ventura.bottle.tar.gz
==> Fetching readline
==> Downloading https://ghcr.io/v2/homebrew/core/readline/manifests/8.2.1
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/ab483c9a913ae82f3a2b3ae20918791bc3bd6825c7122a29cd4f1e0c65413759--readline-8.2.1.bottle_manifest.json
==> Downloading https://ghcr.io/v2/homebrew/core/readline/blobs/sha256:fba42a9bd6feaa8902ae4491ffdf177662e0a165a0d0ddef0988ad6ecf0f23dd
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/1d2d645220a91b8ac8869d09ddf0206070cd2f4278dddcfcc106eefb86be3c6c--readline--8.2.1.arm64_ventura.bottle.tar.gz
==> Fetching sqlite
==> Downloading https://ghcr.io/v2/homebrew/core/sqlite/manifests/3.40.1
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/7fd91ab10b1f27fb37534ed0c5e09b611d2ab5bc8d1e02eedb0b02fbdcf297c3--sqlite-3.40.1.bottle_manifest.json
==> Downloading https://ghcr.io/v2/homebrew/core/sqlite/blobs/sha256:e19a160e1012ed0d58f0e1f631d6954c2bb6feb3cf9f8e9417d6f8955b81236d
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/0c38480a9faa6109343614f2fec8fc268e3ded9ac2c544f4bb1ba4d1ea31bf26--sqlite--3.40.1.arm64_ventura.bottle.tar.gz
==> Fetching python@3.10
==> Downloading https://ghcr.io/v2/homebrew/core/python/3.10/manifests/3.10.9
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/fea5100db04d223d92afe7166db6ed7d5cfd033e941b490f34f12a9ba6ba99c9--python@3.10-3.10.9.bottle_manifest.json
==> Downloading https://ghcr.io/v2/homebrew/core/python/3.10/blobs/sha256:b6bfa71a7d5f6188a1a28e45aed1e8ee08e0e4be11f99ed6d27774b149994364
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/7a53e3a2faeb75713663f1cd1fe5ec67dc045ec62ad1b87db042c55dc54b13b7--python@3.10--3.10.9.arm64_ventura.bottle.tar.gz
==> Fetching teensy_loader_cli
==> Downloading https://ghcr.io/v2/homebrew/core/teensy_loader_cli/manifests/2.2
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/2f99d575d947737a575322bba1a69c4b898016547804e1fd4eff58d542d25161--teensy_loader_cli-2.2.bottle_manifest.json
==> Downloading https://ghcr.io/v2/homebrew/core/teensy_loader_cli/blobs/sha256:97148c203288820eb1f651a744f6bd0867b38383671ec7b7d0961504ecfc51ad
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/9f06a0baa47a1c5451ebd6102717315a158e71ed5ca8478a62d228025ccf35a2--teensy_loader_cli--2.2.arm64_ventura.bottle.tar.gz
==> Fetching qmk/qmk/qmk
==> Downloading https://files.pythonhosted.org/packages/d7/d8/05696357e0311f5b5c316d7b95f46c669dd9c15aaeecbb48c7d0aeb88c40/appdirs-1.4.4.tar.gz
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/d46628d315f103ea527907020cf5f6c94365bbb549783f75a794526482afb672--appdirs-1.4.4.tar.gz
==> Downloading https://files.pythonhosted.org/packages/05/f8/67851ae4fe5396ba6868c5d84219b81ea6a5d53991a6853616095c30adc0/argcomplete-2.0.0.tar.gz
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/d80b401c80fa060d397ef1e894495831c216b23802b5943dfd8ac212e3e31f6f--argcomplete-2.0.0.tar.gz
==> Downloading https://files.pythonhosted.org/packages/1a/cb/c4ffeb41e7137b23755a45e1bfec9cbb76ecf51874c6f1d113984ecaa32c/attrs-22.1.0.tar.gz
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/8108507f92eecf1db105ec3399ff5b1c928af0968c17e2c9f6fc4b8ab7c1801f--attrs-22.1.0.tar.gz
==> Downloading https://files.pythonhosted.org/packages/2b/65/24d033a9325ce42ccbfa3ca2d0866c7e89cc68e5b9d92ecaba9feef631df/colorama-0.4.5.tar.gz
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/cd3c0455424aa953b463cc8c3e88bda00024799daba38cc4ccea21c114aa5158--colorama-0.4.5.tar.gz
==> Downloading https://files.pythonhosted.org/packages/6a/ab/88d67f02024700b48cd8232579ad1316aa9df2272c63049c27cc094229d6/dotty_dict-1.3.1.tar.gz
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/f1545a11fd229c96a9d0f72b7028be9698be626008009829b9fdea774f414101--dotty_dict-1.3.1.tar.gz
==> Downloading https://files.pythonhosted.org/packages/ee/48/d53580d30b1fabf25d0d1fcc3f5b26d08d2ac75a1890ff6d262f9f027436/halo-0.0.31.tar.gz
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/4727d0b748b50e2e4f5fc42c047873878b3acf304a09b3b89d933855dd178535--halo-0.0.31.tar.gz
==> Downloading https://files.pythonhosted.org/packages/e0/2a/87d8d87343c9be4f839972b0a3bef66b8b4f0d350cda11f2d3d8222f29ab/hid-1.0.5.tar.gz
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/5f08cde856aeda7005a327dd63dadc71658841bb4ebb1a42f7dc372c8783e653--hid-1.0.5.tar.gz
==> Downloading https://files.pythonhosted.org/packages/82/e5/0b56d723a76ca67abadbf7fb71609fb0ea7e6926e94fcca6c65a85b36a0e/hjson-3.1.0.tar.gz
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/8acb1b2658a24095b64da16979200ec54f83525a38700902cc6f125b05d70371--hjson-3.1.0.tar.gz
==> Downloading https://files.pythonhosted.org/packages/fb/f3/44393ff5be9008b92207162da8c8cb692d22d1ef13b913772f1642294ef4/jsonschema-4.13.0.tar.gz
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/5251ccdd36fae541cc4d2fc83394cb79e492846ef1ba9a484203d30434034cf3--jsonschema-4.13.0.tar.gz
==> Downloading https://files.pythonhosted.org/packages/45/87/e86645d758a4401c8c81914b6a88470634d1785c9ad09823fa4a1bd89250/log_symbols-0.0.14.tar.gz
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/cb11b132d31dbe503e62ecf5e3c89fc1f33e804b9e3920826bb28e0fa94d300b--log_symbols-0.0.14.tar.gz
==> Downloading https://files.pythonhosted.org/packages/92/c0/3377091d68d98f7448e9e3624d6692548efcd98917cc48a69efb650a3eb4/milc-1.6.6.tar.gz
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/4eae820ef084c651ba53c34792df6f4889cfef58879cf2b41f626a76b7693f8d--milc-1.6.6.tar.gz
==> Downloading https://files.pythonhosted.org/packages/8c/92/2975b464d9926dc667020ed1abfa6276e68c3571dcb77e43347e15ee9eed/Pillow-9.2.0.tar.gz
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/bc794bd01f698c8c5f21e3dc88b94aff82b239596e0bbdcf7f157c74dc329c3c--Pillow-9.2.0.tar.gz
==> Downloading https://files.pythonhosted.org/packages/e0/ef/5905cd3642f2337d44143529c941cc3a02e5af16f0f65f81cbef7af452bb/Pygments-2.13.0.tar.gz
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/9fa20b611f82473c8c9d488adcec4b4c581c79c54080d8a46b2979a67720868b--Pygments-2.13.0.tar.gz
==> Downloading https://files.pythonhosted.org/packages/42/ac/455fdc7294acc4d4154b904e80d964cc9aae75b087bbf486be04df9f2abd/pyrsistent-0.18.1.tar.gz
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/dc555fdd34304dbbde680a019283ec640b66188e51afe042e85db9a6a2075a39--pyrsistent-0.18.1.tar.gz
==> Downloading https://files.pythonhosted.org/packages/1e/7d/ae3f0a63f41e4d2f6cb66a5b57197850f919f59e558159a4dd3a818f5082/pyserial-3.5.tar.gz
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/9539dfa1f22434f69c7dc3a036dd8901eab0d487816cb11aa706e220b6d967ca--pyserial-3.5.tar.gz
==> Downloading https://files.pythonhosted.org/packages/d9/6e/433a5614132576289b8643fe598dd5d51b16e130fd591564be952e15bb45/pyusb-1.2.1.tar.gz
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/e34b8c197df27ea358bb20b554183616eb7d38ee383c4f254133e71f8370816b--pyusb-1.2.1.tar.gz
==> Downloading https://files.pythonhosted.org/packages/71/39/171f1c67cd00715f190ba0b100d606d440a28c93c7714febeca8b79af85e/six-1.16.0.tar.gz
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/3090f0022e8388f5c3bbff25d19f54b7af62562659cbf599e5f7fb044f280199--six-1.16.0.tar.gz
==> Downloading https://files.pythonhosted.org/packages/d3/91/bb331f0a43e04d950a710f402a0986a54147a35818df0e1658551c8d12e1/spinners-0.0.24.tar.gz
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/97375e1304f55f3a8697849128ced63c797b28555b69ee9528d20fc9034097d2--spinners-0.0.24.tar.gz
==> Downloading https://files.pythonhosted.org/packages/8a/48/a76be51647d0eb9f10e2a4511bf3ffb8cc1e6b14e9e4fab46173aa79f981/termcolor-1.1.0.tar.gz
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/2f663a83eb738377295cb9dece37a7fa4dea54dbfb7b86bcacf96bc2035bc58d--termcolor-1.1.0.tar.gz
==> Downloading https://files.pythonhosted.org/packages/52/4a/27caeef7f15316271adaf9d3f03390869be85fd72fbbed950137a5a50900/qmk-1.1.1.tar.gz
Already downloaded: /Users/kjuq/Library/Caches/Homebrew/downloads/776e677253669e66640dff7c339bafea6566673f9d7565a6bb05bc00fedd3e96--qmk-1.1.1.tar.gz
==> Installing qmk from qmk/qmk
==> Installing dependencies for qmk/qmk/qmk: hidapi, icu4c, xz, lz4, zstd, boost, confuse, libusb, libftdi, libusb-compat, avrdude, bootloadhid, clang-format, dfu-programmer, dfu-util, make, mdloader, osx-cross/arm/arm-gcc-bin@8, m4, autoconf, automake, texinfo, avr-binutils, gmp, isl, mpfr, libmpc, osx-cross/avr/avr-gcc@8, jpeg-turbo, libimagequant, libpng, freetype, fribidi, fontconfig, pcre2, gettext, glib, xorgproto, libxau, libxdmcp, libxcb, libx11, libxext, libxrender, lzo, pixman, cairo, graphite2, harfbuzz, libraqm, libtiff, little-cms2, openjpeg, ca-certificates, openssl@1.1, tcl-tk, giflib, webp, pillow, gdbm, mpdecimal, readline, sqlite, python and teensy_loader_cli
==> Installing qmk/qmk/qmk dependency: hidapi
==> Pouring hidapi--0.13.1.arm64_ventura.bottle.tar.gz
🍺  /opt/homebrew/Cellar/hidapi/0.13.1: 19 files, 189.5KB
==> Installing qmk/qmk/qmk dependency: icu4c
==> Pouring icu4c--72.1.arm64_ventura.bottle.tar.gz
🍺  /opt/homebrew/Cellar/icu4c/72.1: 263 files, 78.4MB
==> Installing qmk/qmk/qmk dependency: xz
==> Pouring xz--5.4.1.arm64_ventura.bottle.tar.gz
🍺  /opt/homebrew/Cellar/xz/5.4.1: 95 files, 1.7MB
==> Installing qmk/qmk/qmk dependency: lz4
==> Pouring lz4--1.9.4.arm64_ventura.bottle.tar.gz
🍺  /opt/homebrew/Cellar/lz4/1.9.4: 22 files, 680.1KB
==> Installing qmk/qmk/qmk dependency: zstd
==> Pouring zstd--1.5.2.arm64_ventura.bottle.3.tar.gz
🍺  /opt/homebrew/Cellar/zstd/1.5.2: 31 files, 2.2MB
==> Installing qmk/qmk/qmk dependency: boost
==> Pouring boost--1.81.0_1.arm64_ventura.bottle.tar.gz
🍺  /opt/homebrew/Cellar/boost/1.81.0_1: 15,831 files, 481.6MB
==> Installing qmk/qmk/qmk dependency: confuse
==> Pouring confuse--3.3.arm64_ventura.bottle.tar.gz
🍺  /opt/homebrew/Cellar/confuse/3.3: 15 files, 243.2KB
==> Installing qmk/qmk/qmk dependency: libusb
==> Pouring libusb--1.0.26.arm64_ventura.bottle.tar.gz
🍺  /opt/homebrew/Cellar/libusb/1.0.26: 22 files, 595KB
==> Installing qmk/qmk/qmk dependency: libftdi
==> Pouring libftdi--1.5_2.arm64_ventura.bottle.tar.gz
🍺  /opt/homebrew/Cellar/libftdi/1.5_2: 58 files, 1.1MB
==> Installing qmk/qmk/qmk dependency: libusb-compat
==> Pouring libusb-compat--0.1.8.arm64_ventura.bottle.tar.gz
🍺  /opt/homebrew/Cellar/libusb-compat/0.1.8: 14 files, 134.5KB
==> Installing qmk/qmk/qmk dependency: avrdude
==> Pouring avrdude--7.0_2.arm64_ventura.bottle.tar.gz
🍺  /opt/homebrew/Cellar/avrdude/7.0_2: 9 files, 2.4MB
==> Installing qmk/qmk/qmk dependency: bootloadhid
==> Pouring bootloadhid--2012-12-08.arm64_ventura.bottle.tar.gz
🍺  /opt/homebrew/Cellar/bootloadhid/2012-12-08: 6 files, 80.4KB
==> Installing qmk/qmk/qmk dependency: clang-format
==> Pouring clang-format--15.0.7.arm64_ventura.bottle.tar.gz
🍺  /opt/homebrew/Cellar/clang-format/15.0.7: 10 files, 2.8MB
==> Installing qmk/qmk/qmk dependency: dfu-programmer
==> Pouring dfu-programmer--0.7.2.arm64_ventura.bottle.tar.gz
🍺  /opt/homebrew/Cellar/dfu-programmer/0.7.2: 9 files, 162.3KB
==> Installing qmk/qmk/qmk dependency: dfu-util
==> Pouring dfu-util--0.11.arm64_ventura.bottle.tar.gz
🍺  /opt/homebrew/Cellar/dfu-util/0.11: 13 files, 285.9KB
==> Installing qmk/qmk/qmk dependency: make
==> Pouring make--4.4.arm64_ventura.bottle.tar.gz
🍺  /opt/homebrew/Cellar/make/4.4: 16 files, 1.2MB
==> Installing qmk/qmk/qmk dependency: mdloader
==> make prefix=/opt/homebrew/Cellar/mdloader/1.0.7
/opt/homebrew/Library/Taps/qmk/homebrew-qmk/Formula/mdloader.rb:16: warning: conflicting chdir during another chdir block
🍺  /opt/homebrew/Cellar/mdloader/1.0.7: 5 files, 110.7KB, built in 1 second
==> Installing qmk/qmk/qmk dependency: osx-cross/arm/arm-gcc-bin@8
🍺  /opt/homebrew/Cellar/arm-gcc-bin@8/8-2019-q3-update_2: 5,775 files, 509.4MB, built in 13 seconds
==> Installing qmk/qmk/qmk dependency: m4
==> Pouring m4--1.4.19.arm64_ventura.bottle.tar.gz
🍺  /opt/homebrew/Cellar/m4/1.4.19: 13 files, 742.4KB
==> Installing qmk/qmk/qmk dependency: autoconf
==> Pouring autoconf--2.71.arm64_ventura.bottle.tar.gz
🍺  /opt/homebrew/Cellar/autoconf/2.71: 71 files, 3.2MB
==> Installing qmk/qmk/qmk dependency: automake
==> Pouring automake--1.16.5.arm64_ventura.bottle.tar.gz
🍺  /opt/homebrew/Cellar/automake/1.16.5: 131 files, 3.5MB
==> Installing qmk/qmk/qmk dependency: texinfo
==> Pouring texinfo--7.0.2.arm64_ventura.bottle.tar.gz
🍺  /opt/homebrew/Cellar/texinfo/7.0.2: 417 files, 9MB
==> Installing qmk/qmk/qmk dependency: avr-binutils
==> Patching
==> Applying avr-size.patch
patching file 'binutils/size.c'
==> Applying avr-binutils-elf-bfd-gdb-fix.patch
patching file 'bfd/elf-bfd.h'
==> ../configure --prefix=/opt/homebrew/Cellar/avr-binutils/2.40 --libdir=/opt/homebrew/Cellar/avr-binutils/2.40/lib/avr --infodir=/opt/homebrew/Cellar/avr-binutils/2.40/sh
==> make
==> make install
🍺  /opt/homebrew/Cellar/avr-binutils/2.40: 159 files, 13.6MB, built in 1 minute 2 seconds
==> Installing qmk/qmk/qmk dependency: gmp
==> Pouring gmp--6.2.1_1.arm64_ventura.bottle.tar.gz
🍺  /opt/homebrew/Cellar/gmp/6.2.1_1: 21 files, 3.2MB
==> Installing qmk/qmk/qmk dependency: isl
==> Pouring isl--0.25.arm64_ventura.bottle.tar.gz
🍺  /opt/homebrew/Cellar/isl/0.25: 73 files, 7.4MB
==> Installing qmk/qmk/qmk dependency: mpfr
==> Pouring mpfr--4.2.0.arm64_ventura.bottle.tar.gz
🍺  /opt/homebrew/Cellar/mpfr/4.2.0: 30 files, 3MB
==> Installing qmk/qmk/qmk dependency: libmpc
==> Pouring libmpc--1.3.1.arm64_ventura.bottle.tar.gz
🍺  /opt/homebrew/Cellar/libmpc/1.3.1: 12 files, 470KB
==> Installing qmk/qmk/qmk dependency: osx-cross/avr/avr-gcc@8
==> Patching
==> Applying gcc-11-arm-darwin.patch
patching file 'gcc/config/host-darwin.c'
==> ../configure --target=avr --prefix=/opt/homebrew/Cellar/avr-gcc@8/8.5.0 --libdir=/opt/homebrew/Cellar/avr-gcc@8/8.5.0/lib/avr-gcc/8 --enable-languages=c,c++ --with-ld=/
==> make BOOT_LDFLAGS=-Wl,-headerpad_max_install_names
==> make install
Forcing build system to aarch64-apple-darwin.
==> ./configure --prefix=/opt/homebrew/Cellar/avr-gcc@8/8.5.0 --host=avr
==> make install
🍺  /opt/homebrew/Cellar/avr-gcc@8/8.5.0: 1,753 files, 223.2MB, built in 7 minutes 15 seconds
==> Installing qmk/qmk/qmk dependency: jpeg-turbo
==> Pouring jpeg-turbo--2.1.4.arm64_ventura.bottle.tar.gz
🍺  /opt/homebrew/Cellar/jpeg-turbo/2.1.4: 44 files, 2.5MB
==> Installing qmk/qmk/qmk dependency: libimagequant
==> Pouring libimagequant--4.1.0.arm64_ventura.bottle.tar.gz
🍺  /opt/homebrew/Cellar/libimagequant/4.1.0: 11 files, 12.8MB
==> Installing qmk/qmk/qmk dependency: libpng
==> Pouring libpng--1.6.39.arm64_ventura.bottle.tar.gz
🍺  /opt/homebrew/Cellar/libpng/1.6.39: 27 files, 1.3MB
==> Installing qmk/qmk/qmk dependency: freetype
==> Pouring freetype--2.12.1.arm64_ventura.bottle.tar.gz
🍺  /opt/homebrew/Cellar/freetype/2.12.1: 67 files, 2.3MB
==> Installing qmk/qmk/qmk dependency: fribidi
==> Pouring fribidi--1.0.12.arm64_ventura.bottle.tar.gz
🍺  /opt/homebrew/Cellar/fribidi/1.0.12: 67 files, 662.1KB
==> Installing qmk/qmk/qmk dependency: fontconfig
==> Pouring fontconfig--2.14.2.arm64_ventura.bottle.tar.gz
==> Regenerating font cache, this may take a while
==> /opt/homebrew/Cellar/fontconfig/2.14.2/bin/fc-cache -frv
🍺  /opt/homebrew/Cellar/fontconfig/2.14.2: 88 files, 2.4MB
==> Installing qmk/qmk/qmk dependency: pcre2
==> Pouring pcre2--10.42.arm64_ventura.bottle.tar.gz
🍺  /opt/homebrew/Cellar/pcre2/10.42: 230 files, 6.2MB
==> Installing qmk/qmk/qmk dependency: gettext
==> Pouring gettext--0.21.1.arm64_ventura.bottle.tar.gz
🍺  /opt/homebrew/Cellar/gettext/0.21.1: 1,983 files, 20.9MB
==> Installing qmk/qmk/qmk dependency: glib
==> Pouring glib--2.74.5.arm64_ventura.bottle.tar.gz
🍺  /opt/homebrew/Cellar/glib/2.74.5: 449 files, 21.9MB
==> Installing qmk/qmk/qmk dependency: xorgproto
==> Pouring xorgproto--2022.2.arm64_ventura.bottle.tar.gz
🍺  /opt/homebrew/Cellar/xorgproto/2022.2: 268 files, 3.9MB
==> Installing qmk/qmk/qmk dependency: libxau
==> Pouring libxau--1.0.11.arm64_ventura.bottle.tar.gz
🍺  /opt/homebrew/Cellar/libxau/1.0.11: 21 files, 123.5KB
==> Installing qmk/qmk/qmk dependency: libxdmcp
==> Pouring libxdmcp--1.1.4.arm64_ventura.bottle.tar.gz
🍺  /opt/homebrew/Cellar/libxdmcp/1.1.4: 11 files, 130.4KB
==> Installing qmk/qmk/qmk dependency: libxcb
==> Pouring libxcb--1.15.arm64_ventura.bottle.2.tar.gz
🍺  /opt/homebrew/Cellar/libxcb/1.15: 2,461 files, 7.3MB
==> Installing qmk/qmk/qmk dependency: libx11
==> Pouring libx11--1.8.3.arm64_ventura.bottle.tar.gz
🍺  /opt/homebrew/Cellar/libx11/1.8.3: 1,054 files, 7MB
==> Installing qmk/qmk/qmk dependency: libxext
==> Pouring libxext--1.3.5.arm64_ventura.bottle.tar.gz
🍺  /opt/homebrew/Cellar/libxext/1.3.5: 87 files, 445.8KB
==> Installing qmk/qmk/qmk dependency: libxrender
==> Pouring libxrender--0.9.11.arm64_ventura.bottle.tar.gz
🍺  /opt/homebrew/Cellar/libxrender/0.9.11: 12 files, 213.9KB
==> Installing qmk/qmk/qmk dependency: lzo
==> Pouring lzo--2.10.arm64_ventura.bottle.tar.gz
🍺  /opt/homebrew/Cellar/lzo/2.10: 31 files, 566.3KB
==> Installing qmk/qmk/qmk dependency: pixman
==> Pouring pixman--0.42.2.arm64_ventura.bottle.tar.gz
🍺  /opt/homebrew/Cellar/pixman/0.42.2: 11 files, 842.5KB
==> Installing qmk/qmk/qmk dependency: cairo
==> Pouring cairo--1.16.0_5.arm64_ventura.bottle.tar.gz
🍺  /opt/homebrew/Cellar/cairo/1.16.0_5: 126 files, 6.4MB
==> Installing qmk/qmk/qmk dependency: graphite2
==> Pouring graphite2--1.3.14.arm64_ventura.bottle.tar.gz
🍺  /opt/homebrew/Cellar/graphite2/1.3.14: 18 files, 281.2KB
==> Installing qmk/qmk/qmk dependency: harfbuzz
==> Pouring harfbuzz--6.0.0_1.arm64_ventura.bottle.tar.gz
🍺  /opt/homebrew/Cellar/harfbuzz/6.0.0_1: 69 files, 8MB
==> Installing qmk/qmk/qmk dependency: libraqm
==> Pouring libraqm--0.10.0.arm64_ventura.bottle.tar.gz
🍺  /opt/homebrew/Cellar/libraqm/0.10.0: 11 files, 89.8KB
==> Installing qmk/qmk/qmk dependency: libtiff
==> Pouring libtiff--4.4.0_1.arm64_ventura.bottle.1.tar.gz
🍺  /opt/homebrew/Cellar/libtiff/4.4.0_1: 249 files, 4.8MB
==> Installing qmk/qmk/qmk dependency: little-cms2
==> Pouring little-cms2--2.14.arm64_ventura.bottle.tar.gz
🍺  /opt/homebrew/Cellar/little-cms2/2.14: 21 files, 1.4MB
==> Installing qmk/qmk/qmk dependency: openjpeg
==> Pouring openjpeg--2.5.0.arm64_ventura.bottle.1.tar.gz
🍺  /opt/homebrew/Cellar/openjpeg/2.5.0: 536 files, 13.9MB
==> Installing qmk/qmk/qmk dependency: ca-certificates
==> Pouring ca-certificates--2023-01-10.all.bottle.tar.gz
==> Regenerating CA certificate bundle from keychain, this may take a while...
🍺  /opt/homebrew/Cellar/ca-certificates/2023-01-10: 3 files, 216.9KB
==> Installing qmk/qmk/qmk dependency: openssl@1.1
==> Pouring openssl@1.1--1.1.1s.arm64_ventura.bottle.tar.gz
🍺  /opt/homebrew/Cellar/openssl@1.1/1.1.1s: 8,101 files, 18MB
==> Installing qmk/qmk/qmk dependency: tcl-tk
==> Pouring tcl-tk--8.6.13.arm64_ventura.bottle.tar.gz
🍺  /opt/homebrew/Cellar/tcl-tk/8.6.13: 3,070 files, 53MB
==> Installing qmk/qmk/qmk dependency: giflib
==> Pouring giflib--5.2.1.arm64_ventura.bottle.tar.gz
🍺  /opt/homebrew/Cellar/giflib/5.2.1: 19 files, 540.2KB
==> Installing qmk/qmk/qmk dependency: webp
==> Pouring webp--1.3.0.arm64_ventura.bottle.tar.gz
🍺  /opt/homebrew/Cellar/webp/1.3.0: 47 files, 2.3MB
==> Installing qmk/qmk/qmk dependency: pillow
==> Pouring pillow--9.4.0.arm64_ventura.bottle.tar.gz
🍺  /opt/homebrew/Cellar/pillow/9.4.0: 219 files, 4.2MB
==> Installing qmk/qmk/qmk dependency: gdbm
==> Pouring gdbm--1.23.arm64_ventura.bottle.tar.gz
🍺  /opt/homebrew/Cellar/gdbm/1.23: 24 files, 1MB
==> Installing qmk/qmk/qmk dependency: mpdecimal
==> Pouring mpdecimal--2.5.1.arm64_ventura.bottle.tar.gz
🍺  /opt/homebrew/Cellar/mpdecimal/2.5.1: 71 files, 2.2MB
==> Installing qmk/qmk/qmk dependency: readline
==> Pouring readline--8.2.1.arm64_ventura.bottle.tar.gz
🍺  /opt/homebrew/Cellar/readline/8.2.1: 50 files, 1.7MB
==> Installing qmk/qmk/qmk dependency: sqlite
==> Pouring sqlite--3.40.1.arm64_ventura.bottle.tar.gz
🍺  /opt/homebrew/Cellar/sqlite/3.40.1: 11 files, 4.4MB
==> Installing qmk/qmk/qmk dependency: python
==> Pouring python@3.10--3.10.9.arm64_ventura.bottle.tar.gz
==> /opt/homebrew/Cellar/python@3.10/3.10.9/bin/python3.10 -m ensurepip
==> /opt/homebrew/Cellar/python@3.10/3.10.9/bin/python3.10 -m pip install -v --no-deps --no-index --upgrade --isolated --target=/opt/homebrew/lib/python3.10/site-packages /
🍺  /opt/homebrew/Cellar/python@3.10/3.10.9: 3,110 files, 57.1MB
==> Installing qmk/qmk/qmk dependency: teensy_loader_cli
==> Pouring teensy_loader_cli--2.2.arm64_ventura.bottle.tar.gz
🍺  /opt/homebrew/Cellar/teensy_loader_cli/2.2: 4 files, 62.4KB
==> Installing qmk/qmk/qmk
==> python3 -m venv --system-site-packages /opt/homebrew/Cellar/qmk/1.1.1/libexec
==> /opt/homebrew/Cellar/qmk/1.1.1/libexec/bin/pip install -v --no-deps --no-binary :all: --use-feature=no-binary-enable-wheel-cache --ignore-installed /private/tmp/qmk--ap
==> /opt/homebrew/Cellar/qmk/1.1.1/libexec/bin/pip install -v --no-deps --no-binary :all: --use-feature=no-binary-enable-wheel-cache --ignore-installed /private/tmp/qmk--ar
==> /opt/homebrew/Cellar/qmk/1.1.1/libexec/bin/pip install -v --no-deps --no-binary :all: --use-feature=no-binary-enable-wheel-cache --ignore-installed /private/tmp/qmk--at
==> /opt/homebrew/Cellar/qmk/1.1.1/libexec/bin/pip install -v --no-deps --no-binary :all: --use-feature=no-binary-enable-wheel-cache --ignore-installed /private/tmp/qmk--co
==> /opt/homebrew/Cellar/qmk/1.1.1/libexec/bin/pip install -v --no-deps --no-binary :all: --use-feature=no-binary-enable-wheel-cache --ignore-installed /private/tmp/qmk--do
==> /opt/homebrew/Cellar/qmk/1.1.1/libexec/bin/pip install -v --no-deps --no-binary :all: --use-feature=no-binary-enable-wheel-cache --ignore-installed /private/tmp/qmk--ha
==> /opt/homebrew/Cellar/qmk/1.1.1/libexec/bin/pip install -v --no-deps --no-binary :all: --use-feature=no-binary-enable-wheel-cache --ignore-installed /private/tmp/qmk--hi
==> /opt/homebrew/Cellar/qmk/1.1.1/libexec/bin/pip install -v --no-deps --no-binary :all: --use-feature=no-binary-enable-wheel-cache --ignore-installed /private/tmp/qmk--hj
==> /opt/homebrew/Cellar/qmk/1.1.1/libexec/bin/pip install -v --no-deps --no-binary :all: --use-feature=no-binary-enable-wheel-cache --ignore-installed /private/tmp/qmk--js
==> /opt/homebrew/Cellar/qmk/1.1.1/libexec/bin/pip install -v --no-deps --no-binary :all: --use-feature=no-binary-enable-wheel-cache --ignore-installed /private/tmp/qmk--lo
==> /opt/homebrew/Cellar/qmk/1.1.1/libexec/bin/pip install -v --no-deps --no-binary :all: --use-feature=no-binary-enable-wheel-cache --ignore-installed /private/tmp/qmk--mi
==> /opt/homebrew/Cellar/qmk/1.1.1/libexec/bin/pip install -v --no-deps --no-binary :all: --use-feature=no-binary-enable-wheel-cache --ignore-installed /private/tmp/qmk--Pi
Last 15 lines from /Users/kjuq/Library/Logs/Homebrew/qmk/13.pip:
  else:
      filename = "<auto-generated setuptools caller>"
      setup_py_code = "from setuptools import setup; setup()"
  
  exec(compile(setup_py_code, filename, "exec"))
  '"'"''"'"''"'"' % ('"'"'/private/tmp/qmk--Pillow-20230130-62478-enp5o7/Pillow-9.2.0/setup.py'"'"',), "<pip-setuptools-caller>", "exec"))' install --record /private/tmp/pip-record-pbqld3sl/install-record.txt --single-version-externally-managed --compile --install-headers /opt/homebrew/Cellar/qmk/1.1.1/libexec/include/site/python3.10/Pillow
  cwd: /private/tmp/qmk--Pillow-20230130-62478-enp5o7/Pillow-9.2.0/
  Running setup.py install for Pillow: finished with status 'error'
error: legacy-install-failure

× Encountered error while trying to install package.
╰─> Pillow

note: This is an issue with the package mentioned above, not pip.
hint: See above for output from the failure.

Do not report this issue to Homebrew/brew or Homebrew/core!
</code></pre>
</details>