### PR TITLE
fix: mdloader sha256 sum

### DIFF
--- a/Formula/mdloader.rb
+++ b/Formula/mdloader.rb
@@ -2,7 +2,7 @@ class Mdloader < Formula
   desc "Massdrop Firmware Loader"
   homepage "https://github.com/Massdrop/mdloader"
   url "https://github.com/Massdrop/mdloader/archive/1.0.7.tar.gz"
-  sha256 "a3c47ed285aaa94e9a5c00c84a15798e6d90f1bb13db846cc71cad6eb4a2d7c4"
+  sha256 "0d2d679849c8edbe0b67eaf2bdc69a4a0ced07d009008a01d8f9d81fa8a49b51"
   head "https://github.com/Massdrop/mdloader"
 
   bottle do


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

mdloader sha256 sum appears to be wrong.

<!--- Describe your changes in detail here. -->
<!--- Mention 'Fixed #<issue_number>' (eg 'Fixed #1234') to link to fixed issues. -->

## Environment

Macbook Air M1
macOS Ventura 13.2
