### PR TITLE
qmk: add pkg-config as build dependency for M1

### DIFF
--- a/Formula/qmk.rb
+++ b/Formula/qmk.rb
@@ -28,6 +28,10 @@ class Qmk < Formula
   depends_on "python"
   depends_on "teensy_loader_cli"
 
+  on_arm do
+    depends_on "pkg-config" => :build
+  end
+
   resource "appdirs" do
     url "https://files.pythonhosted.org/packages/d7/d8/05696357e0311f5b5c316d7b95f46c669dd9c15aaeecbb48c7d0aeb88c40/appdirs-1.4.4.tar.gz"
     sha256 "7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Now that I have an M1 machine to test with, I can confirm adding `pkg-config` to the build dependencies for arm64 fixes #53.