### PR TITLE
changed arm-gcc-bin to be version 10

### DIFF
--- a/Formula/qmk.rb
+++ b/Formula/qmk.rb
@@ -25,7 +25,7 @@ class Qmk < Formula
   depends_on "libusb"
   depends_on "make"
   depends_on "mdloader"
-  depends_on "osx-cross/arm/arm-gcc-bin@8"
+  depends_on "osx-cross/arm/arm-gcc-bin@10"
   depends_on "osx-cross/avr/avr-gcc@8"
   depends_on "pillow"
   depends_on "python"


### PR DESCRIPTION
The compiled firmware from MacOS when using SonixQMK on Keychrons seemed to cause an issue if too many keys were pressed or randomly the firmware appeared to just crash and flash some leds sometimes holding the last input.


## Description

Updating lines in a couple repos attempting to get this squared away, as pointed out here https://github.com/SonixQMK/qmk_firmware/issues/336

I'm also creating a fork and pull request on the SonixQMK Firmware https://github.com/SonixQMK/qmk_firmware will edit with that pull request.

Pull request on sonixqmkfirmware https://github.com/SonixQMK/qmk_firmware/pull/345
