### PR TITLE
Drop macOS 11

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
   test-bot:
     strategy:
       matrix:
-        os: [macos-11, macos-12, macos-13]
+        os: [macos-12, macos-13]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Set up Homebrew

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   update:
-    runs-on: macos-11
+    runs-on: macos-12
     steps:
       - name: Update Homebrew formula
         uses: dawidd6/action-homebrew-bump-formula@v3


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Homebrew has upped their minimum macOS version to Monterey (12): https://docs.brew.sh/Installation

As such, builds for Big Sur will start failing due to unbottled dependencies: https://github.com/qmk/homebrew-qmk/actions/runs/6541203415/job/17762375559?pr=66

No runner yet for Sonoma, though.