### PR TITLE
Drop Monterey, add Sequoia

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
   test-bot:
     strategy:
       matrix:
-        os: [macos-12, macos-13, macos-14]
+        os: [macos-13, macos-14, macos-15]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Set up Homebrew


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Bottles no longer being built for Monterey (12) as Homebrew minimum version is now Ventura (13). Getting unbottled dependencies error for (at least) `pillow` on #83.

Sequoia (15) has been added to actions/runner-images, so let's see if things Just Work.
