### PR TITLE
update workflow: switch runner to macos-latest

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   update:
-    runs-on: macos-12
+    runs-on: macos-latest
     steps:
       - name: Update Homebrew formula
         uses: dawidd6/action-homebrew-bump-formula@v3


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Since macOS 12 runners are deprecated; the specific version doesn't really matter.
